### PR TITLE
Adding product name to ad spots endpoint

### DIFF
--- a/pybarb/pybarb.py
+++ b/pybarb/pybarb.py
@@ -904,6 +904,11 @@ class AdvertisingSpotsResultSet(APIResultSet):
                             ]
                             if e["clearcast_information"] is not None
                             else None,
+                            "clearcast_product_name": e["clearcast_information"][
+                            "product_name"
+                            ]
+                            if e["clearcast_information"] is not None
+                            else None,
                             "campaign_approval_id": e["campaign_approval_id"],
                             "sales_house_name": e["sales_house"]["sales_house_name"],
                             "audience_name": v["description"],


### PR DESCRIPTION
As requested by Mike Futcher from OMC, updating the advertising spots endpoint to include the product name in the endpoint output.